### PR TITLE
Remove use of `ProductDetailRoute::load` in `ProductHelper` to increase performance.

### DIFF
--- a/src/Components/Helper/ProductHelper.php
+++ b/src/Components/Helper/ProductHelper.php
@@ -39,7 +39,6 @@ class ProductHelper
     /**
      * @param $productId
      * @param $context
-     * @return SalesChannelProductEntity|null
      */
     public function getSalesChannelSeoCategoryByProductId($productId, $context): ?CategoryEntity
     {

--- a/src/Components/Helper/ProductHelper.php
+++ b/src/Components/Helper/ProductHelper.php
@@ -36,22 +36,21 @@ class ProductHelper
         return $productCollection->get($productId);
     }
 
-    /**
-     * @param $productId
-     * @param $context
-     */
-    public function getSalesChannelSeoCategoryByProductId($productId, $context): ?CategoryEntity
+    public function getProductsById($productIds, $context): ProductCollection
     {
-        $criteria = new Criteria();
-        $criteria->setIds([$productId]);
-        $criteria->setTitle('product-detail-route');
+        $criteria = new Criteria($productIds);
+        $criteria->addAssociation('seoUrls');
 
-        $product = $this->productRepository->search($criteria, $context)->getEntities()->first();
+        /** @var ProductCollection $productCollection */
+        return $this->productRepository->search($criteria, $context->getContext())->getEntities();
+    }
 
-        if ($product === null) {
-            return null;
-        }
-
+    /**
+     * @param ProductEntity $product
+     * @param SalesChannelContext $context
+     */
+    public function getSalesChannelSeoCategoryByProduct($product, $context): ?CategoryEntity
+    {
         return $this->breadcrumbBuilder->getProductSeoCategory($product, $context);
     }
 

--- a/src/Components/Helper/ProductHelper.php
+++ b/src/Components/Helper/ProductHelper.php
@@ -4,35 +4,22 @@
  */
 namespace Dtgs\GoogleTagManager\Components\Helper;
 
-use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
+use Shopware\Core\Content\Category\CategoryEntity;
+use Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductEntity;
-use Shopware\Core\Content\Product\SalesChannel\Detail\AbstractProductDetailRoute;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\Uuid\Exception\InvalidUuidException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Symfony\Component\HttpFoundation\Request;
 
 class ProductHelper
 {
-
-    /**
-     * @var EntityRepository
-     */
-    private EntityRepository $productRepository;
-
-    /**
-     * @var AbstractProductDetailRoute
-     */
-    private AbstractProductDetailRoute $productDetailRoute;
-
-    public function __construct(EntityRepository $productRepository,
-                                AbstractProductDetailRoute $productDetailRoute)
+    public function __construct(
+        private EntityRepository $productRepository,
+        private CategoryBreadcrumbBuilder $breadcrumbBuilder,
+    )
     {
-        $this->productRepository = $productRepository;
-        $this->productDetailRoute = $productDetailRoute;
     }
 
     /**
@@ -54,15 +41,19 @@ class ProductHelper
      * @param $context
      * @return SalesChannelProductEntity|null
      */
-    public function getSalesChannelProductEntityByProductId($productId, $context)
+    public function getSalesChannelSeoCategoryByProductId($productId, $context): ?CategoryEntity
     {
-        try {
-            $result = $this->productDetailRoute->load($productId, new Request(), $context, new Criteria());
-        }
-        catch (InvalidUuidException|ProductNotFoundException|\Exception $exception) {
+        $criteria = new Criteria();
+        $criteria->setIds([$productId]);
+        $criteria->setTitle('product-detail-route');
+
+        $product = $this->productRepository->search($criteria, $context)->getEntities()->first();
+
+        if ($product === null) {
             return null;
         }
-        return $result->getProduct();
+
+        return $this->breadcrumbBuilder->getProductSeoCategory($product, $context);
     }
 
 }

--- a/src/DependencyInjection/helper.xml
+++ b/src/DependencyInjection/helper.xml
@@ -17,7 +17,7 @@
         </service>
         <service id="Dtgs\GoogleTagManager\Components\Helper\ProductHelper">
             <argument type="service" id="product.repository"/>
-            <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Detail\ProductDetailRoute"/>
+            <argument type="service" id="Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder" />
         </service>
         <service id="Dtgs\GoogleTagManager\Components\Helper\ManufacturerHelper">
             <argument type="service" id="product_manufacturer.repository"/>

--- a/src/Services/Ga4Service.php
+++ b/src/Services/Ga4Service.php
@@ -440,6 +440,21 @@ class Ga4Service
         $tags = array();
         if(empty($listing)) return $tags;
 
+        $realProductIds = [];
+        if ($addCategoryNames) {
+            foreach ($listing as $lineItem) {
+                /** @var LineItem $lineItem */
+                if ($lineItem->getReferencedId()) {
+                    $realProductIds[] = $lineItem->getReferencedId();
+                }
+            }
+        }
+
+        $realProducts = null;
+        if (count($realProductIds)) {
+            $realProducts = $this->productHelper->getProductsById($realProductIds, $context);
+        }
+
         foreach($listing as $product) {
             /** @var LineItem $product */
             $taxRate = $product->getPrice()->getTaxRules()->first();
@@ -501,8 +516,11 @@ class Ga4Service
             //Product Category - Changed to SEO Category in V6.1.22
             if($addCategoryNames) {
                 if($product->getType() == 'promotion') continue;
-                if($product->getReferencedId()) {
-                    $seoCategory = $this->productHelper->getSalesChannelSeoCategoryByProductId($product->getReferencedId(), $context);
+                if($product->getReferencedId() && $realProducts && $realProducts->has($product->getReferencedId())) {
+                    $seoCategory = $this->productHelper->getSalesChannelSeoCategoryByProductId(
+                        $realProducts->get($product->getReferencedId()),
+                        $context,
+                    );
                     if($seoCategory !== null) {
                         $item['item_category'] = $seoCategory->getTranslation('name');
                     }

--- a/src/Services/Ga4Service.php
+++ b/src/Services/Ga4Service.php
@@ -502,9 +502,9 @@ class Ga4Service
             if($addCategoryNames) {
                 if($product->getType() == 'promotion') continue;
                 if($product->getReferencedId()) {
-                    $salesChannelProduct = $this->productHelper->getSalesChannelProductEntityByProductId($product->getReferencedId(), $context);
-                    if($salesChannelProduct !== null && $salesChannelProduct->getSeoCategory() !== null) {
-                        $item['item_category'] = $salesChannelProduct->getSeoCategory()->getTranslation('name');
+                    $seoCategory = $this->productHelper->getSalesChannelSeoCategoryByProductId($product->getReferencedId(), $context);
+                    if($seoCategory !== null) {
+                        $item['item_category'] = $seoCategory->getTranslation('name');
                     }
                 }
             }


### PR DESCRIPTION
The only think needed from the `ProductDetailRoute::load` call in `ProductHelper` is the SEO Category of the product. 

By using `CategoryBreadcrumbBuilder` directly in `ProductHelper` we can achieve this by avoiding going through tons of other unrelated calls, queries and code. In a default store, this call might not take a lot of time, but if the product is pimped by other plugins to be much more complex. 

In addition `Ga4Service` performs one query each for fetching the product instead of fetching all products at once. This N+1 query is also removed.

This refactoring saved a customer of mine almost 6 seconds of processing time on the Cart page.

This is a screenshot from Tideways showing the performance improvement:

<img width="1132" height="495" alt="Bildschirmfoto 2025-10-21 um 18 39 35" src="https://github.com/user-attachments/assets/81f71de0-9dc6-45a0-9b31-3a65cfb45163" />

One downside, renaming the method on `ProductHelper` to `getSalesChannelSeoCategoryByProduct` might cause problems for store owners that decorated the service to overwrite `getSalesChannelProductEntityByProductId`. Since both the arguments and return type is also changed I believe that is fine.

`getManufacturerById` is another N+1 that could also be removed by the same pattern.

Also https://github.com/codiversegbr/DtgsGoogleTagManagerSw6/issues/18 looks related and this seems a fix for it.